### PR TITLE
Calc a hash from generated code

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = postcss.plugin('postcss-hash', (opts) => {
 
         // replace filename
         originalName = result.opts.to;
-        result.opts.to = utils.rename(originalName, root.source.input.css, opts);
+        result.opts.to = utils.rename(originalName, root.toString(), opts);
 
         // create/update manifest.json
         newData = utils.data(originalName, result.opts.to);


### PR DESCRIPTION
By this change, this plugin can calc a hash correctly even if only a "node" css file gathered by postcss is changed.

Fix https://github.com/dacodekid/postcss-hash/issues/2