### PR TITLE
feat: add `name` function option for customising the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Hash's length.
 ### manifest `(string, default: './manifest.json')`
 Will output a `manifest` file with `key: value` pairs.
 
+### name `(function, default: ({dir, name, hash, ext}) => path.join(dir, name + '.' + hash + ext)
+Pass a function to customise the name of the output file. The function is given an object of string values:
+
+ - dir: the directory name as a string
+ - name: the name of the file, excluding any extensions
+ - hash: the resulting hash digest of the file
+ - ext: the extension of the file
+
 **NOTE:**
 1. The values will be either appended or replaced. If this file needs be recreated on each run, you'll have to manually delete it.
 2. `key`s are generated with files' `basename`. If you have `./input/A/one.css` & `./input/B/one.css`, only the last entry will exist.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = postcss.plugin('postcss-hash', (opts) => {
     opts = _.defaults(opts, {
         algorithm: 'md5',
         trim: 10,
-        manifest: './manifest.json'
+        manifest: './manifest.json',
+        name: utils.defaultName
     });
 
     return function (root, result) {

--- a/index.test.js
+++ b/index.test.js
@@ -47,9 +47,20 @@ test('hash module', () => {
     expect(utils.hash(content(file), 'sha256', 5)).toHaveLength(5);
 });
 
+test('defaultName module', () => {
+    const parts = {
+        dir: 'in',
+        name: 'file01',
+        hash: 'deadbeef',
+        ext: '.css'
+    };
+    expect.assertions(1);
+    expect(utils.defaultName(parts)).toBe('in/file01.deadbeef.css');
+});
+
 test('rename module', () => {
     const file = './in/file01.css';
-    const opts = { algorithm: 'sha', trim: 5 };
+    const opts = { algorithm: 'sha256', trim: 5, name: utils.defaultName };
     const hash = utils.hash(content(file), opts.algorithm, opts.trim);
 
     expect.assertions(1);
@@ -58,7 +69,7 @@ test('rename module', () => {
 
 test('data module', () => {
     const file = './in/file01.css';
-    const opts = { algorithm: 'md5', trim: 5 };
+    const opts = { algorithm: 'md5', trim: 5, name: utils.defaultName };
     const renamedFile = utils.rename(file, content(file), opts);
 
     expect.assertions(1);

--- a/utils.js
+++ b/utils.js
@@ -13,15 +13,22 @@ function hash(css, algorithm, trim) {
       .substr(0, trim);
 }
 
+
+function defaultName(parts) {
+    return path.join(parts.dir, parts.name + '.' + parts.hash + parts.ext);
+}
+
 /*
 a function to rename a filename by appending hash value.
 input: ('./file.css', 'a {}', {algorithm: 'sha256', trim: 10})   output: ./file.a1b2c3d4e5.css
 */
 function rename(file, css, opts) {
-    return file
-      .substr(0, file.lastIndexOf('.')) + '.' +
-      hash(css, opts.algorithm, opts.trim) +
-      path.extname(file);
+    return opts.name({
+        dir: path.dirname(file),
+        name : path.basename(file, path.extname(file)),
+        ext: path.extname(file),
+        hash: hash(css, opts.algorithm, opts.trim)
+    });
 }
 
 /*
@@ -39,4 +46,5 @@ function data(originalName, hashedName) {
 
 module.exports.hash = hash;
 module.exports.rename = rename;
+module.exports.defaultName = defaultName;
 module.exports.data = data;


### PR DESCRIPTION
This adds a `name` option - which is a function that is called with the requisite parts of the file name: directory, file name, hash and extension. This way users can customise the output of the file name to their liking. 

The motiviation behind this is that I'm using this on a project that already has a convention of `file-hash.ext` and would like to keep to that convention. This tool however does `file.hash.ext`, so I'd like to customise that behavior.