### PR TITLE
feat: provide option to also hash the sourcemap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 cache: yarn
 node_js:
-  - 6 # to be removed 2019-04-01
   - 8 # to be removed 2019-12-01
   - 10 # to be removed 2021-04-01
   - lts/* # safety net; don't remove

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ module.exports = (ctx) => ({
 ### algorithm `(string, default: 'md5')`
 Uses node's inbuilt [crypto] module. Pass any `digest algorithm` that is supported in your environment. Possible values are: `md5`, `md4`, `md2`, `sha`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`.
 
+### includeMap `(boolean, default: false)`
+Setting `includeMap` to `true` will allow postcss-hash to hash the name of the sourcemap, as well hash the CSS _including_ the `sourceMappingURL` comment. You can set this option to true if you care about the hashed fingerprints matching the contents of the CSS file, and don't mind a performance hit of regenerating the CSS twice.
+
 
 ### trim `(number, default: 10)`
 Hash's length.

--- a/index.js
+++ b/index.js
@@ -52,7 +52,6 @@ module.exports = postcss.plugin("postcss-hash", opts => {
             // to the CSS and returns it as res[0]
             const res = map.generate()
 
-            console.log('changing opts.to', res[0])
             result.opts.to = utils.rename(originalName, res[0], opts);
         } else {
             result.opts.to = utils.rename(originalName, root.toString(), opts);

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 "use strict";
 
 const { readFileSync, writeFileSync } = require("fs");
-const { dirname } = require("path");
+const { dirname, basename } = require("path");
 const postcss = require("postcss");
+const MapGenerator = require("postcss/lib/map-generator");
 const utils = require("./utils");
 const mkdirp = require("mkdirp");
 
@@ -12,6 +13,7 @@ module.exports = postcss.plugin("postcss-hash", opts => {
             algorithm: "md5",
             trim: 10,
             manifest: "./manifest.json",
+            includeMap: false,
             name: utils.defaultName
         },
         opts
@@ -21,6 +23,40 @@ module.exports = postcss.plugin("postcss-hash", opts => {
         // replace filename
         const originalName = result.opts.to;
         result.opts.to = utils.rename(originalName, root.toString(), opts);
+
+        // In order to get content addressable hash names, we need to generate
+        // and hash the map file first, which gives us the ability to hash that,
+        // then we can do a full map.generate() which will apply the sourceMappingURL
+        // to the CSS file, allowing us to do a full hash of the CSS including
+        // thes sourceMappingURL comment.
+        if (opts.includeMap) {
+            // Extract the stringifier
+            let str = postcss.stringify;
+            if (result.opts.syntax) str = result.opts.syntax.stringify;
+            if (result.opts.stringifier) str = result.opts.stringifier;
+            if (str.stringify) str = str.stringify;
+
+            // Generate the sourceMap contents
+            const map = new MapGenerator(str, root, result.opts);
+            map.generateString();
+
+            const hash = utils.rename(originalName, map.map.toString(), opts);
+
+            // If the sourcemap annotation option is set, then we can name the sourcemap
+            // based on the contents of its map, so change the option to be a string.
+            if (result.opts.map) {
+                result.opts.map.annotation = basename(`${hash}.map`);
+            }
+
+            // need to call map.generate() which applies the sourceMappingURL comment
+            // to the CSS and returns it as res[0]
+            const res = map.generate()
+
+            console.log('changing opts.to', res[0])
+            result.opts.to = utils.rename(originalName, res[0], opts);
+        } else {
+            result.opts.to = utils.rename(originalName, root.toString(), opts);
+        }
 
         // create/update manifest.json
         const newData = utils.data(originalName, result.opts.to);

--- a/index.test.js
+++ b/index.test.js
@@ -138,3 +138,29 @@ test("plugin ensures manifest directory is created", () => {
             expect(result.warnings().length).toBe(0);
         });
 });
+
+test("plugin will hash sourcemap with includeMap", () => {
+    const opts = {
+        algorithm: "sha512",
+        trim: 5,
+        includeMap: true,
+        manifest: join(tmpdir(), "foo/bar/baz/manifest.json")
+    };
+    const filePath = join(tmpdir(), "file01.css");
+    return postcss([plugin(opts)])
+        .process(readFileSync(filePath, "utf-8"), {
+            from: filePath,
+            to: filePath,
+            map: { inline: false },
+        })
+        .then(result => {
+            const hash = utils.hash(
+                '.a {}\n/*# sourceMappingURL=file01.88aab.css.map */',
+                opts.algorithm,
+                opts.trim
+            );
+
+            expect(result.opts.to).toMatch(new RegExp(hash));
+            expect(result.warnings().length).toBe(0);
+        });
+});

--- a/index.test.js
+++ b/index.test.js
@@ -154,12 +154,10 @@ test("plugin will hash sourcemap with includeMap", () => {
             map: { inline: false },
         })
         .then(result => {
-            const hash = utils.hash(
-                '.a {}\n/*# sourceMappingURL=file01.88aab.css.map */',
-                opts.algorithm,
-                opts.trim
-            );
+            const expectedOutput = '.a {}\n/*# sourceMappingURL=file01.88aab.css.map */';
+            const hash = utils.hash(expectedOutput, opts.algorithm, opts.trim);
 
+            expect(result.css).toEqual(expectedOutput);
             expect(result.opts.to).toMatch(new RegExp(hash));
             expect(result.warnings().length).toBe(0);
         });


### PR DESCRIPTION
This allows sourcemaps to be hashed, and the CSS file's sourceMappingURL also gets hashed!