### PR TITLE
Use GitHub Actions instead of Travis CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,19 @@
+name: Node CI
+
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build
+        npm test
+      env:
+        CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-cache: yarn
-node_js:
-  - 8 # to be removed 2019-12-01
-  - 10 # to be removed 2021-04-01
-  - lts/* # safety net; don't remove
-  - node # safety net; don't remove


### PR DESCRIPTION
I find GitHub actions to be quite a bit faster than Travis so I figured I'd suggest this change. It might have to be enabled by an admin.