### PR TITLE
Use `OnceExit` to ensure hashing is done after other plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = opts => {
 
     return {
         postcssPlugin: "postcss-hash",
-        Once(root, { result, stringify }) {
+        OnceExit(root, { result, stringify }) {
             // replace filename
             const originalName = result.opts.to;
             result.opts.to = utils.rename(originalName, root.toString(), opts);


### PR DESCRIPTION
The PostCSS docs are pretty minimal, but I think this will fix an issue I was having where PostCSS would do hashing on un-minified CSS files, and then it would minify, causing hash mismatches in my project.

https://postcss.org/api/#plugin-onceexit